### PR TITLE
refactor(ai): type the copilot composer's voice input

### DIFF
--- a/ui/scripts/explicit-any/baseline.json
+++ b/ui/scripts/explicit-any/baseline.json
@@ -93,7 +93,6 @@
   "src/components/SurveyDialog.vue": 1,
   "src/components/admin/triggers/AddTriggerModal.spec.ts": 1,
   "src/components/admin/triggers/AddTriggerModal.vue": 5,
-  "src/components/ai/copilot/CopilotComposer.vue": 5,
   "src/components/basicauth/BasicAuthLogin.vue": 2,
   "src/components/basicauth/BasicAuthSetup.vue": 7,
   "src/components/content/BigChildCards.vue": 1,

--- a/ui/src/components/ai/copilot/CopilotComposer.vue
+++ b/ui/src/components/ai/copilot/CopilotComposer.vue
@@ -210,7 +210,7 @@
     // Transcript captured before this dictation started, so interim results append cleanly.
     const baseDraft = ref("")
     const draftBeforeListening = ref("")
-    let recognition: any = null
+    let recognition: SpeechRecognition | null = null
 
     // Waveform visualizer.
     const wavesContainer = ref<HTMLElement | null>(null)
@@ -237,7 +237,7 @@
             volumeBuffer.value = Array(barCount).fill(0)
 
             stream = await navigator.mediaDevices.getUserMedia({audio: true})
-            audioContext = new (window.AudioContext || (window as any).webkitAudioContext)()
+            audioContext = new (window.AudioContext || window.webkitAudioContext)()
             analyser = audioContext.createAnalyser()
             analyser.fftSize = 256
             analyser.smoothingTimeConstant = 0.3
@@ -330,13 +330,13 @@
     })
 
     onMounted(() => {
-        const SR = (window as any).SpeechRecognition || (window as any).webkitSpeechRecognition
+        const SR = window.SpeechRecognition || window.webkitSpeechRecognition
         if (!SR) return
         speechSupported.value = true
         recognition = new SR()
         recognition.continuous = true
         recognition.interimResults = true
-        recognition.onresult = (event: any) => {
+        recognition.onresult = (event: SpeechRecognitionEvent) => {
             let interim = ""
             for (let i = event.resultIndex; i < event.results.length; i++) {
                 const result = event.results[i]

--- a/ui/src/speech-recognition.d.ts
+++ b/ui/src/speech-recognition.d.ts
@@ -1,0 +1,26 @@
+// The Web Speech API recognizer and the webkit-prefixed globals it is exposed under.
+// TypeScript's DOM lib ships the result side (SpeechRecognitionEvent, SpeechRecognitionResult,
+// SpeechRecognitionAlternative) but not the recognizer itself, which is still an unofficial
+// Community Group draft, nor webkitSpeechRecognition / webkitAudioContext. Only the members the
+// app uses are declared, and the constructors are reached through window rather than declared
+// as globals, so a future lib.dom that adds them cannot collide with this file.
+
+interface SpeechRecognition extends EventTarget {
+    continuous: boolean
+    interimResults: boolean
+    onresult: ((this: SpeechRecognition, event: SpeechRecognitionEvent) => void) | null
+    onend: ((this: SpeechRecognition, event: Event) => void) | null
+    start(): void
+    stop(): void
+    abort(): void
+}
+
+interface SpeechRecognitionConstructor {
+    new (): SpeechRecognition
+}
+
+interface Window {
+    SpeechRecognition?: SpeechRecognitionConstructor
+    webkitSpeechRecognition?: SpeechRecognitionConstructor
+    webkitAudioContext?: typeof AudioContext
+}


### PR DESCRIPTION
Closes #19304.

All five explicit `any` in `CopilotComposer.vue` were in the voice input: the Web Speech recognizer and the `webkitAudioContext` prefix.

## Where the types come from

TypeScript's DOM lib (6.0.3, the locked version) already ships the result side of the Web Speech API: `SpeechRecognitionEvent`, `SpeechRecognitionResult`, `SpeechRecognitionResultList` and `SpeechRecognitionAlternative`. It does not ship the recognizer itself, which is still an unofficial Community Group draft, nor the vendor-prefixed `webkitSpeechRecognition` and `webkitAudioContext`.

Following step 2 of #19266:

- The `onresult` handler now uses the lib's `SpeechRecognitionEvent`.
- The rest goes into `src/speech-recognition.d.ts`, next to `src/material-icons.d.ts`. It declares only the members the composer uses (`continuous`, `interimResults`, `onresult`, `onend`, `start`, `stop`, `abort`) and augments `Window` with the two optional constructors plus `webkitAudioContext`.

The constructors are reached through `window` rather than declared as globals. If a future lib.dom adds `SpeechRecognition`, the interfaces merge and nothing collides. I did not pull in `@types/dom-speech-recognition`: the ambient declaration is seven members, and a new dependency seemed heavier than the problem.

## What the typing surfaced

Nothing. With the recognizer typed, `check:types` compiled the app, the design system and the tests with no new errors. The composer's single caller, `CopilotChat.vue`, never touches the recognizer.

## Checks

- `npm run check:ts-any`: `CopilotComposer.vue: 5 -> 0`, and the file drops out of `baseline.json`. On today's `develop` that takes the count from 1543 to 1538 explicit `any`, and from 389 to 388 files. The branch is rebased onto `develop` and the updated baseline is committed.
- `npm run check:types`: passes for the design system, the app and the tests.
- `oxlint` and `eslint` on the changed files: clean.
- `vitest run --project=unit tests/unit/components/ai/copilot`: 15 files, 178 tests passed. That includes the existing check that voice input degrades to no mic button when jsdom has no `SpeechRecognition`.
