### PR TITLE
fix(ai): grow the copilot composer around a prompt that is already in it when it opens

### DIFF
--- a/ui/src/components/ai/copilot/CopilotComposer.vue
+++ b/ui/src/components/ai/copilot/CopilotComposer.vue
@@ -177,6 +177,9 @@
         const el = textareaEl.value
         if (!el) return
         el.style.height = "auto"
+        // A composer that is mounted but not laid out yet (dock still opening) measures zero and would
+        // collapse the box - leave the rows-based height, the observer below re-runs once it has one.
+        if (el.scrollHeight === 0) return
         el.style.height = `${el.scrollHeight}px`
     }
 
@@ -195,6 +198,31 @@
 
     // Keep the height in sync when the draft is cleared (e.g. after submit).
     watch(draft, () => nextTick(autosize))
+
+    /*
+        `input` and the draft watcher only cover text that arrives once the composer is on screen. A
+        seeded prompt ("Fix with AI", the editor shortcut) is already in the model by the time the
+        composer mounts - the chat swaps from the empty state to the footer composer, or the dock opens
+        on a rehydrated thread - so the box stayed one row tall around a multiline prompt. Size it on
+        mount, and again whenever the box gets a new width: a narrower dock rewraps the draft onto more
+        lines, and a mount inside a panel that is not laid out yet first measures a width of zero.
+    */
+    let lastWidth = 0
+    const resizeObserver = new ResizeObserver((entries) => {
+        const width = entries[0]?.contentRect.width ?? 0
+        if (width === lastWidth) return
+        lastWidth = width
+        autosize()
+    })
+
+    // Re-runs whenever the textarea is (re)created too - dictation swaps it out for the waveform.
+    watch(textareaEl, (el, previous) => {
+        if (previous) resizeObserver.unobserve(previous)
+        if (!el) return
+        lastWidth = el.clientWidth
+        autosize()
+        resizeObserver.observe(el)
+    }, {flush: "post"})
 
     // Enter submits; Shift+Enter inserts a newline.
     function onKeydown(event: KeyboardEvent): void {
@@ -357,6 +385,7 @@
             // ignore
         }
         stopAudioAnalysis()
+        resizeObserver.disconnect()
     })
 </script>
 

--- a/ui/tests/unit/components/ai/copilot/CopilotComposer.spec.ts
+++ b/ui/tests/unit/components/ai/copilot/CopilotComposer.spec.ts
@@ -1,4 +1,5 @@
-import {describe, it, expect} from "vitest"
+import {describe, it, expect, vi} from "vitest"
+import {nextTick} from "vue"
 import {mount} from "@vue/test-utils"
 import CopilotComposer from "../../../../../src/components/ai/copilot/CopilotComposer.vue"
 import {mountGlobal} from "./_helpers"
@@ -70,6 +71,19 @@ describe("CopilotComposer", () => {
         expect((input(w).element as HTMLTextAreaElement).value).toBe("Fix this error")
         // A seeded prompt is submittable straight away.
         expect(sendBtn(w).attributes("disabled")).toBeUndefined()
+    })
+
+    it("grows to fit a multiline draft that is already in the model when it mounts", async () => {
+        // jsdom has no layout, so stand in for the height a multiline draft would measure.
+        const scrollHeight = vi.spyOn(HTMLTextAreaElement.prototype, "scrollHeight", "get").mockReturnValue(210)
+        try {
+            const w = mountComposer({modelValue: "Fix this flow\n\njava.lang.RuntimeException\n\tat io.kestra"})
+            await nextTick()
+            // Without sizing on mount the box keeps its one-row height around the whole prompt.
+            expect((input(w).element as HTMLTextAreaElement).style.height).toBe("210px")
+        } finally {
+            scrollHeight.mockRestore()
+        }
     })
 
     it("emits update:modelValue as the user types", async () => {


### PR DESCRIPTION
## What

The `AI Copilot` composer only grew around text that arrived after it was on screen: it sizes its `textarea` from `input` events and from a watcher on the draft. A seeded prompt - "Fix with AI" on a failed `execution` or `task run`, or from an error toast - is already in the model by the time the composer mounts, because the chat swaps from the empty state to the footer composer, or the dock opens on a `thread` that rehydrates a moment later. Neither path fires for a value that was there from the start, so a multiline prompt sat in a one-row box that had to be scrolled line by line.

Reported on Slack by Ludo, who hit it on Linux + Chrome; nothing about it is platform-specific, it only depends on the prompt already being in the composer when it appears. Typing or pasting multiline text was never affected, which is why it did not reproduce on macOS.

The `textarea` is now sized when it is created, and again whenever it gets a new width - a narrower dock rewraps the draft onto more lines, and a composer created inside a panel that has no layout yet gets measured once it has one. A composer that measures zero keeps its rows-based height instead of collapsing.

The unit test covers the regression: mounted with a multiline `modelValue`, the box takes the content height instead of staying one row.

## Before

The whole prompt in a one-row box, scrolled line by line.

![before](https://raw.githubusercontent.com/MilosPaunovic/kestra/aacabc6f72b9bd55c2fb8273291d1eb7f57185e7/copilot-composer-multiline/before.png)

## After

The same prompt, sized to its content and capped at the composer's `9rem` max height.

![after](https://raw.githubusercontent.com/MilosPaunovic/kestra/aacabc6f72b9bd55c2fb8273291d1eb7f57185e7/copilot-composer-multiline/after.png)

## Video

The same seeded prompt in both clips, Linux + Chromium. Before - the box stays 21px tall around 210px of content and has to be scrolled line by line:

[copilot-composer-before.webm](https://github.com/user-attachments/assets/581c9c15-68bc-4369-85cf-12ba48789b1a)

After - the same prompt, sized to its content and capped at the composer's `9rem` max height:

[copilot-composer-after.webm](https://github.com/user-attachments/assets/6bead80d-2d2c-452b-bd28-bdbd11a411a1)


Related to https://github.com/kestra-io/kestra/pull/19388.
