### PR TITLE
feat(ai): surface the AI Copilot with a button in the top bar

### DIFF
--- a/ui/src/components/layout/AppTopNavBar.vue
+++ b/ui/src/components/layout/AppTopNavBar.vue
@@ -35,6 +35,17 @@
             <div id="topnav-actions-slot" class="d-flex gap-2 align-items-center" />
         </template>
         <template #panel-toggle>
+            <KsButton
+                v-if="showCopilotButton"
+                class="copilot-button"
+                :class="{'is-open': isCopilotOpen}"
+                data-testid="topnav-copilot-button"
+                :icon="AiMenuIcon"
+                :aria-pressed="isCopilotOpen"
+                @click="toggleCopilot"
+            >
+                {{ $t("ai.copilot.title") }}
+            </KsButton>
             <slot name="panel-toggle" />
         </template>
     </KsTopNavBar>
@@ -43,7 +54,9 @@
 <script setup lang="ts">
     import {computed, ref, watch} from "vue"
     import {useRoute, useRouter} from "vue-router"
+    import {KsButton} from "@kestra-io/design-system"
     import GlobalSearch from "./GlobalSearch.vue"
+    import AiMenuIcon from "../ai/AiMenuIcon.vue"
     import {useBookmarksStore} from "../../stores/bookmarks"
     import {useLayoutStore} from "../../stores/layout"
     import {useTopNavStore} from "../../stores/topNav"
@@ -66,6 +79,16 @@
 
     function togglePanel() {
         miscStore.contextInfoBarOpenTab = miscStore.contextInfoBarOpenTab ? "" : miscStore.lastContextTab
+    }
+
+    const isCopilotOpen = computed(() => miscStore.contextInfoBarOpenTab === "ai")
+
+    function toggleCopilot() {
+        if (isCopilotOpen.value) {
+            miscStore.contextInfoBarOpenTab = ""
+            return
+        }
+        miscStore.openCopilot()
     }
 
     const selectTabs = computed(() =>
@@ -117,6 +140,20 @@
     })
 
     const activeMenuIcon = computed(() => activeMenuItem.value?.icon?.element)
+
+    // The menu resolves its hrefs to path strings, so match on where the item leads rather than
+    // on the shape of its href.
+    const isCopilotMenuItem = (item: MenuItem) =>
+        !item.child && !!item.href && router.resolve(item.href).name === "ai"
+
+    // The top bar entry follows the left-menu copilot item, so whatever hides that item (EE hides
+    // it for users without the COPILOT permission) hides this button too, with no second copy of
+    // the rule. It also stays out of the way on the full-page copilot, where the dock tab it opens
+    // is hidden.
+    const showCopilotButton = computed(() => {
+        const item = flattenMenu(menu.value).find(isCopilotMenuItem)
+        return !!item && !item.hidden && route.name !== "ai"
+    })
 
     const hideBookmark = computed(() => {
         const href = activeMenuItem.value?.href
@@ -179,6 +216,19 @@
 </script>
 
 <style scoped lang="scss">
+    .copilot-button {
+        flex-shrink: 0;
+
+        &.is-open {
+            color: var(--ks-text-link);
+        }
+
+        // Same breakpoint as the dock toggle it sits next to: the dock it opens is desktop-only.
+        @media (max-width: 767px) {
+            display: none;
+        }
+    }
+
     .playgroundMode {
         background:
             linear-gradient(

--- a/ui/tests/unit/components/layout/AppTopNavBarCopilotButton.spec.ts
+++ b/ui/tests/unit/components/layout/AppTopNavBarCopilotButton.spec.ts
@@ -1,0 +1,169 @@
+import {afterEach, beforeEach, describe, expect, it, vi} from "vitest"
+import {mount} from "@vue/test-utils"
+import {createPinia, setActivePinia} from "pinia"
+import {reactive} from "vue"
+import {createI18n} from "vue-i18n"
+
+// Reactive so a test can move to the full-page copilot, where the button must disappear.
+const route = reactive({
+    fullPath: "/main/flows",
+    name: "flows/list" as string,
+    path: "/main/flows",
+    meta: {},
+    params: {},
+    query: {},
+})
+
+// `useLeftMenu` hands out hrefs already resolved to path strings, so the router mock maps those
+// paths (and still-raw route objects) back to route names the way the real router would.
+const routeNames: Record<string, string> = {
+    "/main/dashboards": "home",
+    "/main/ai": "ai",
+    "/main/flows": "flows/list",
+}
+
+vi.mock("vue-router", () => ({
+    useRoute: () => route,
+    useRouter: () => ({
+        resolve: vi.fn((to: string | {name?: string}) => ({name: typeof to === "string" ? routeNames[to] : to.name})),
+        push: vi.fn(),
+    }),
+}))
+
+vi.mock("../../../../src/components/layout/GlobalSearch.vue", () => ({
+    default: {name: "GlobalSearch", template: "<div />"},
+}))
+
+vi.mock("../../../../src/stores/playground", () => ({
+    usePlaygroundStore: () => ({enabled: false}),
+}))
+
+// Mirrors the store contract the button relies on: `openCopilot` selects the dock's copilot tab.
+const miscStore = reactive({
+    contextInfoBarOpenTab: "",
+    lastContextTab: "ai",
+    openCopilot: vi.fn(() => {
+        miscStore.lastContextTab = "ai"
+        miscStore.contextInfoBarOpenTab = "ai"
+    }),
+})
+
+vi.mock("override/stores/misc", () => ({
+    useMiscStore: () => miscStore,
+}))
+
+// Shape of the left menu as `useLeftMenu` builds it: a Workspace section holding the copilot item,
+// every href already turned into a path string.
+const menu = reactive<{value: unknown[]}>({value: []})
+const workspaceWithCopilot = (copilotHidden = false) => [{
+    title: "Workspace",
+    child: [
+        {title: "Dashboards", href: "/main/dashboards", routes: ["home"]},
+        {title: "AI Copilot", href: "/main/ai", routes: ["ai"], hidden: copilotHidden},
+        {title: "Flows", href: "/main/flows", routes: ["flows/list"]},
+    ],
+}]
+
+vi.mock("override/components/useLeftMenu", () => ({
+    useLeftMenu: () => ({menu}),
+}))
+
+import AppTopNavBar from "../../../../src/components/layout/AppTopNavBar.vue"
+
+const KsTopNavBarStub = {name: "KsTopNavBar", template: "<div><slot name=\"panel-toggle\" /></div>"}
+
+const i18n = createI18n({
+    legacy: false,
+    locale: "en",
+    messages: {en: {ai: {copilot: {title: "AI Copilot"}}}},
+})
+
+const mountNavBar = () => mount(AppTopNavBar, {
+    global: {plugins: [i18n], stubs: {KsTopNavBar: KsTopNavBarStub}},
+})
+
+const copilotButton = (wrapper: ReturnType<typeof mountNavBar>) => wrapper.find("[data-testid=\"topnav-copilot-button\"]")
+
+describe("AppTopNavBar AI Copilot button", () => {
+    beforeEach(() => {
+        localStorage.clear()
+        setActivePinia(createPinia())
+        route.name = "flows/list"
+        menu.value = workspaceWithCopilot()
+        miscStore.contextInfoBarOpenTab = ""
+        miscStore.openCopilot.mockClear()
+    })
+
+    afterEach(() => {
+        localStorage.clear()
+    })
+
+    it("shows a labelled AI Copilot button when the left menu offers the copilot", () => {
+        const button = copilotButton(mountNavBar())
+
+        expect(button.exists()).toBe(true)
+        expect(button.text()).toBe("AI Copilot")
+        expect(button.attributes("aria-pressed")).toBe("false")
+    })
+
+    it("opens the copilot dock tab on click", async () => {
+        const wrapper = mountNavBar()
+
+        await copilotButton(wrapper).trigger("click")
+
+        expect(miscStore.openCopilot).toHaveBeenCalledTimes(1)
+        expect(miscStore.contextInfoBarOpenTab).toBe("ai")
+        expect(copilotButton(wrapper).attributes("aria-pressed")).toBe("true")
+        expect(copilotButton(wrapper).classes()).toContain("is-open")
+    })
+
+    it("closes the dock when the copilot tab is already the open one", async () => {
+        miscStore.contextInfoBarOpenTab = "ai"
+        const wrapper = mountNavBar()
+
+        await copilotButton(wrapper).trigger("click")
+
+        expect(miscStore.openCopilot).not.toHaveBeenCalled()
+        expect(miscStore.contextInfoBarOpenTab).toBe("")
+    })
+
+    it("switches to the copilot tab when another dock tab is open", async () => {
+        miscStore.contextInfoBarOpenTab = "docs"
+        const wrapper = mountNavBar()
+
+        expect(copilotButton(wrapper).classes()).not.toContain("is-open")
+
+        await copilotButton(wrapper).trigger("click")
+
+        expect(miscStore.openCopilot).toHaveBeenCalledTimes(1)
+        expect(miscStore.contextInfoBarOpenTab).toBe("ai")
+    })
+
+    it("follows the left menu: hidden copilot item, no button", () => {
+        menu.value = workspaceWithCopilot(true)
+
+        expect(copilotButton(mountNavBar()).exists()).toBe(false)
+    })
+
+    it("renders nothing without a copilot item in the menu", () => {
+        menu.value = [{title: "Workspace", child: [{title: "Flows", href: "/main/flows", routes: ["flows/list"]}]}]
+
+        expect(copilotButton(mountNavBar()).exists()).toBe(false)
+    })
+
+    it("also recognises a copilot item whose href is still a route object", () => {
+        menu.value = [{title: "Workspace", child: [{title: "AI Copilot", href: {name: "ai"}, routes: ["ai"]}]}]
+
+        expect(copilotButton(mountNavBar()).exists()).toBe(true)
+    })
+
+    it("stays out of the way on the full-page copilot", async () => {
+        const wrapper = mountNavBar()
+        expect(copilotButton(wrapper).exists()).toBe(true)
+
+        route.name = "ai"
+        await wrapper.vm.$nextTick()
+
+        expect(copilotButton(wrapper).exists()).toBe(false)
+    })
+})


### PR DESCRIPTION
Closes https://github.com/kestra-io/kestra-ee/issues/10995.

## What

The `AI Copilot` was reachable only from the second item of the left menu and from the tab strip of the right dock, which is easy to miss. The top bar now carries an `AI Copilot` button next to the dock toggle, as in the Figma designs: one click opens the copilot tab of the dock, a second click closes it, and the button reads as pressed (`aria-pressed`, link colour) while that tab is open.

## How

- `AppTopNavBar.vue` renders a `KsButton` with the `AiMenuIcon` in the `panel-toggle` slot of `KsTopNavBar`, so it sits after the page actions and before the `EE` notification bell and the dock toggle.
- The button follows the left-menu copilot item, matched by resolving the item's `href` to the `ai` route (`useLeftMenu` turns every href into a path string, in both `OSS` and `EE`). Whatever hides that item hides the button too - `EE` hides it for users without the `COPILOT` permission - with no second copy of the rule, so no `EE` change is needed.
- It is not rendered on the full-page copilot (`/ai`), where the dock tab it opens is hidden as well, and it hides under 767px like the dock toggle next to it.
- New unit spec `AppTopNavBarCopilotButton.spec.ts` covers visibility (copilot item present, hidden, absent, and on `/ai`), opening, closing, and switching over from another dock tab.

## Screenshots

| Before | After |
|---|---|
| ![before](https://raw.githubusercontent.com/MilosPaunovic/kestra/a243a18192f17390cecf67ff497d4fba1a9f63bc/10995/before.png) | ![after](https://raw.githubusercontent.com/MilosPaunovic/kestra/a243a18192f17390cecf67ff497d4fba1a9f63bc/10995/after.png) |

Dock opened by the button, with the pressed state:

![after, dock open](https://raw.githubusercontent.com/MilosPaunovic/kestra/a243a18192f17390cecf67ff497d4fba1a9f63bc/10995/after-dock-open.png)

Light theme:

![after, light theme](https://raw.githubusercontent.com/MilosPaunovic/kestra/a243a18192f17390cecf67ff497d4fba1a9f63bc/10995/after-light.png)

## Checks

- `npm run check:types` passes in `OSS` and, through a paired worktree carrying this commit, in `EE` (`ui-ee`).
- The three `AppTopNavBar` unit specs pass (14 tests), `eslint` is clean on the changed files.
- Verified against a local `OSS` instance: the button opens the dock on the `AI` tab, closes it on the second click, and is absent on `/ai`.
