### PR TITLE
fix(design-system): await the i18n registration install starts

### DIFF
--- a/ui/AGENTS.md
+++ b/ui/AGENTS.md
@@ -435,6 +435,7 @@ If your `<style>` block needs to exist:
 - `applyDefaultFilters()`, `useRouteFilterPolicy()` — filter composables
 - `setMomentInstance()`, `setDateFormatter()` — date library configuration
 - `designSystemLocale`, `setDesignSystemLocale`, `registerDesignSystemI18n` — i18n
+- `designSystemI18nReady()` — the locale registration the plugin's `install` started, to await instead of leaving it in flight (the unit setup awaits it after each test)
 
 ## Composables
 

--- a/ui/packages/design-system/src/index.ts
+++ b/ui/packages/design-system/src/index.ts
@@ -191,6 +191,11 @@ export {Comparators} from "./components/Data/KsDataTable/filter/utils/filterType
 export type {InputInstance, FormItemRule, FormRules, FormInstance, CascaderOption, CascaderProps} from "element-plus"
 export {TooltipType, ChartRenderer, ChartFeature} from "./utils/chart"
 export {designSystemLocale, setDesignSystemLocale, registerDesignSystemI18n} from "./i18n"
+
+let i18nRegistration: Promise<void> = Promise.resolve()
+
+/** The registration `install` started, so a caller can await it rather than leave it in flight. */
+export const designSystemI18nReady = (): Promise<void> => i18nRegistration
 export {useDiscardGuard} from "./composables/useDiscardGuard"
 export type {FilterContext} from "./components/Data/KsDataTable/filter/utils/filterInjectionKeys"
 export {SAVED_FILTER_ANALYTICS_INJECTION_KEY} from "./components/Data/KsDataTable/filter/utils/filterAnalytics"
@@ -508,7 +513,7 @@ const KestraDesignSystem = {
 
         const symbol = (app as unknown as {__VUE_I18N_SYMBOL__?: symbol}).__VUE_I18N_SYMBOL__
         const i18n = symbol ? (app._context.provides[symbol] as I18n | undefined) : undefined
-        if (i18n) void registerDesignSystemI18n(i18n)
+        if (i18n) i18nRegistration = registerDesignSystemI18n(i18n)
     },
 }
 

--- a/ui/tests/unit/designSystemI18nReady.spec.ts
+++ b/ui/tests/unit/designSystemI18nReady.spec.ts
@@ -1,0 +1,17 @@
+import {describe, expect, it} from "vitest"
+import {createApp} from "vue"
+import {createI18n} from "vue-i18n"
+import KestraDesignSystem, {designSystemI18nReady} from "@kestra-io/design-system"
+
+describe("designSystemI18nReady", () => {
+    it("should resolve once install has merged the design system's own messages", async () => {
+        const i18n = createI18n({legacy: false, locale: "en", messages: {en: {}}})
+        const app = createApp({template: "<div />"})
+        app.use(i18n)
+        app.use(KestraDesignSystem)
+
+        await designSystemI18nReady()
+
+        expect(i18n.global.getLocaleMessage("en")).toHaveProperty("ks_password.show")
+    })
+})

--- a/ui/tests/unit/setup.ts
+++ b/ui/tests/unit/setup.ts
@@ -1,5 +1,6 @@
 import {afterEach, vi} from "vitest"
 import {config, disableAutoUnmount, enableAutoUnmount} from "@vue/test-utils"
+import {designSystemI18nReady} from "@kestra-io/design-system"
 import {installMonacoCssEscapePolyfill} from "./monacoCssEscapePolyfill"
 
 // Required by `isolate: false` (vitest.config.unit.js): workers reuse one module registry, so a
@@ -15,6 +16,10 @@ vi.resetModules()
 // module is shared across files here, so reset it before re-arming per file.
 disableAutoUnmount()
 enableAutoUnmount(afterEach)
+
+// Installing the design system starts a locale-module glob it does not await, so a spec that
+// finishes first is torn down mid-import and the run reports unhandled EnvironmentTeardownErrors.
+afterEach(() => designSystemI18nReady())
 
 // Most unit tests mount a component in isolation, without installing vue-router,
 // so a literal <router-link> in its template can never resolve and spams


### PR DESCRIPTION
### 🔗 Related Issue

None. Found while diagnosing a `Frontend - Tests` failure on https://github.com/kestra-io/kestra/pull/19333, and reproduced on `develop` itself.

### ✨ Description

`Frontend - Tests` fails intermittently on `develop` with **every test passing**:

```
Test Files  255 passed (256)
Tests       2279 passed (2281)
Errors      6 errors
```

The six are unhandled rejections, not test failures — the job's own reporter says `No UI test failures — nothing to report` — and they all read:

```
EnvironmentTeardownError: Cannot load
'.../@kestra-io/design-system/src/components/Navigation/KsTopNavBar/KsTopNavBar.locale.ts'
imported from .../@kestra-io/design-system/src/i18n/index.ts after the environment was torn down.
```

**Cause.** The plugin's `install` fired the registration and dropped it:

```ts
if (i18n) void registerDesignSystemI18n(i18n)
```

`registerDesignSystemI18n` awaits one `import.meta.glob` loader per `*.locale.ts` in sequence. The `void` leaves that chain in flight, so a spec that installs the design system with a real `createI18n` can finish while the loop is still importing, and teardown kills whichever module it had reached. Six tests in one spec, six in-flight chains, six errors. Which locale module gets named is arbitrary — `KsTopNavBar.locale.ts` in CI, `KsPassword.locale.ts` locally — which is what made it look like a different problem on each run rather than one race.

**Fix.** `install` keeps the promise and exposes it as `designSystemI18nReady()`; `ui/tests/unit/setup.ts` awaits it after each test. `src/utils/init.ts:131` already awaited the same call, so the plugin-install path was the only unawaited one, and nothing about production behaviour changes — the registration was always meant to complete, it just had no handle.

### 🎨 Frontend Checklist

- [x] Type checking passes (`npm run check:types` — all three passes)
- [x] Code builds without errors (`npm run build`)
- [x] Unit tests pass (`npm run test:unit`) — 258 files, 2291 tests, **0 errors**, and clean across two `test:unit:shuffle` runs, which matters for a race
- [x] Translations are complete if `en.json` changed — not touched
- [x] Screenshots or video recordings attached showing the `UI` changes — no user-visible change

### 📝 Additional Notes

**Before and after**, same machine, full unit suite:

| | Test Files | Tests | Errors |
|---|---|---|---|
| `develop` at `37e4d3856` | 1 failed / 255 passed | 2 failed / 2279 passed | **6** |
| this branch | 258 passed | 2291 passed | **0** |

(The two failing tests on `develop` are the `logsCursor.spec.ts` timeouts, a separate and already-reported problem that #19341 also describes. They are not touched here.)

**One test**, `tests/unit/designSystemI18nReady.spec.ts`: installs the plugin with an i18n instance, awaits `designSystemI18nReady()`, and asserts a design-system-owned key has been merged. It fails with `expected {} to have property "ks_password.show"` when the `void` is put back, so it pins the regression rather than the implementation. There is no test for the race itself — the suite going from six unhandled errors to none is the evidence for that, and a test that reliably reproduced a teardown race would be pinned to Vitest's scheduling.

**Not run:** `npm run test:storybook`. The storybook project needs a browser this environment cannot install (`@vitest/browser-playwright` fails during setup), so CI is the signal there. `packages/design-system/**` is excluded from the unit project and has its own job, which this change also triggers.

**Scope note:** the new utility is added to `ui/AGENTS.md`'s utilities list, as that file requires for a new design-system export.

A cat knocked a glass off the counter and walked away before it landed. The glass is still falling. This PR is the `await`. 🐱

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XmNZXEzKESw9E7cAXYHovT

---
_Generated by [Claude Code](https://claude.ai/code/session_01XmNZXEzKESw9E7cAXYHovT)_