### PR TITLE
fix(core): compile the secret-masking file appender and the cherry-picked tests

### DIFF
--- a/core/src/main/java/io/kestra/core/runners/RunContextLogger.java
+++ b/core/src/main/java/io/kestra/core/runners/RunContextLogger.java
@@ -310,7 +310,7 @@ public class RunContextLogger implements Supplier<org.slf4j.Logger> {
             this.logger = logger;
         }
 
-        private String replaceSecret(String data) {
+        protected String replaceSecret(String data) {
             for (String s : runContextLogger.useSecrets) {
                 if (data.contains(s)) {
                     data = data.replace(s, "******");

--- a/core/src/test/java/io/kestra/core/runners/RunContextLoggerTest.java
+++ b/core/src/test/java/io/kestra/core/runners/RunContextLoggerTest.java
@@ -320,7 +320,7 @@ class RunContextLoggerTest {
         Flow flow = TestsUtils.mockFlow();
         Execution execution = TestsUtils.mockExecution(flow, Map.of());
         RunContextLogger runContextLogger = new RunContextLogger(
-            logEntryEmitter,
+            logQueue,
             LogEntry.of(execution),
             Level.TRACE,
             true

--- a/core/src/test/java/io/kestra/plugin/core/flow/SwitchTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/flow/SwitchTest.java
@@ -104,7 +104,7 @@ class SwitchTest {
 
         assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
         assertThat(execution.getTaskRunList().get(1).getTaskId()).isEqualTo("default");
-        assertThat((Boolean) taskOutputService.getOutputs(execution.findTaskRunsByTaskId("parent-seq").getFirst()).get("defaults")).isTrue();
+        assertThat((Boolean) execution.findTaskRunsByTaskId("parent-seq").getFirst().getOutputs().get("defaults")).isTrue();
     }
 
     @Test


### PR DESCRIPTION
Related to https://github.com/kestra-io/kestra/pull/19312 (its `CI` is red only because of this).

## What

`releases/v1.3.x` does not compile since three commits were cherry-picked straight onto the branch with develop-only code in them. Every `Backend - Tests` job against the branch fails before running a single test, for example https://github.com/kestra-io/kestra/actions/runs/34591271661/job/103236915742:

- `7e9ff33d86` (`fix(core): mask secrets in log-to-file exception traces`): `FileAppender.append` calls `replaceSecret(String)`, but `BaseAppender` still declares it `private` on this branch (develop and 2.0 have it `protected`), so `core:compileJava` fails. Its new `RunContextLoggerTest.shouldMaskThrowableWhenLoggingToFile` also builds the logger from a `logEntryEmitter` field that only exists on develop; the 1.3 test class injects the log queue directly.
- `3004bfe1aa` (`fix: prevent NPE when Switch task has only defaults and no cases`): the new `SwitchTest.switchDefaultsOnly` reads outputs through a `TaskOutputService` that this branch does not have; task run outputs are read from the task run itself here.

## How

Three one-line adaptations, no behaviour change: `replaceSecret(String)` becomes `protected` as on develop, the logger test passes `logQueue`, and the switch test reads `getOutputs()` on the task run. Verified locally: `core` compiles again and `RunContextLoggerTest` plus `SwitchTest` (19 tests) are green.