### PR TITLE
fix(tasks): route the namespace purge tasks to the system worker

### DIFF
--- a/core/src/main/java/io/kestra/plugin/core/purge/PurgeTask.java
+++ b/core/src/main/java/io/kestra/plugin/core/purge/PurgeTask.java
@@ -11,12 +11,21 @@ import com.google.common.annotations.VisibleForTesting;
 import io.kestra.core.exceptions.IllegalVariableEvaluationException;
 import io.kestra.core.exceptions.ValidationErrorException;
 import io.kestra.core.models.property.Property;
+import io.kestra.core.models.tasks.SystemTask;
 import io.kestra.core.repositories.FlowRepositoryInterface;
 import io.kestra.core.runners.DefaultRunContext;
 import io.kestra.core.runners.RunContext;
 import io.kestra.core.utils.ListUtils;
 
-public interface PurgeTask<T> {
+/**
+ * Base contract for the namespace-scoped purge tasks.
+ *
+ * <p>
+ * Extends {@link SystemTask} because {@link #findNamespaces(RunContext)} resolves internal
+ * Kestra services, which are unreachable from a dedicated Worker process.
+ * </p>
+ */
+public interface PurgeTask<T> extends SystemTask {
     Property<List<String>> getNamespaces();
 
     Property<String> getNamespacePattern();

--- a/tests/src/test/java/io/kestra/tests/architecture/SystemTaskArchitectureTest.java
+++ b/tests/src/test/java/io/kestra/tests/architecture/SystemTaskArchitectureTest.java
@@ -1,0 +1,34 @@
+package io.kestra.tests.architecture;
+
+import com.tngtech.archunit.base.DescribedPredicate;
+import com.tngtech.archunit.core.domain.JavaAccess;
+import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.lang.ArchRule;
+
+import io.kestra.core.models.tasks.SystemTask;
+import io.kestra.core.models.tasks.Task;
+import io.kestra.core.runners.Services;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+
+@AnalyzeClasses(packages = "io.kestra", importOptions = ImportOption.DoNotIncludeTests.class)
+public class SystemTaskArchitectureTest {
+
+    static final DescribedPredicate<JavaAccess<?>> ADDITIONAL_SERVICE_IS_CALLED = DescribedPredicate.describe(
+        "Services.additionalService() is called",
+        access -> access.getTarget().getOwner().isAssignableTo(Services.class)
+            && "additionalService".equals(access.getTarget().getName())
+    );
+
+    @ArchTest
+    public static final ArchRule tasks_reaching_for_internal_services_are_system_tasks = noClasses()
+        .that().areAssignableTo(Task.class)
+        .and().areNotAssignableTo(SystemTask.class)
+        .should().callCodeUnitWhere(ADDITIONAL_SERVICE_IS_CALLED)
+        .because(
+            "Services.additionalService() throws on a dedicated Worker; only a " + SystemTask.class.getName()
+                + " is routed to the SystemWorker, which is the only Worker with access to internal services"
+        );
+}


### PR DESCRIPTION
### 🔗 Related Issue

Companion PR of https://github.com/kestra-io/kestra-ee/pull/11013, which closes https://github.com/kestra-io/kestra-ee/issues/11005.

### ✨ Description

In distributed mode, where the worker runs as its own service, `io.kestra.plugin.core.kv.PurgeKV` and `io.kestra.plugin.core.namespace.PurgeFiles` always fail with `Services.additionalService() cannot be used inside the Worker`, regardless of their arguments. Both need internal Kestra services, and `Services.additionalService()` throws when `kestra.server-type=WORKER`. The `SystemTask` marker is what routes a task to the reserved `system` queue served by the in-process `SystemWorker`, which does have that access — `PurgeFlows`, `PurgeLogs`, `PurgeExecutions` and `PurgeStorage` all carry it, these two did not.

`PurgeTask` now extends `SystemTask`. `PurgeKV` and `PurgeFiles` are its only implementors, and its default `findNamespaces()` already resolves `FlowRepositoryInterface` through `additionalService()`, so the requirement belongs on the interface rather than being repeated on each task.

An ArchUnit rule keeps it that way: no class assignable to `Task` that is not a `SystemTask` may call `Services.additionalService()`.

### 🛠️ Backend Checklist

- [x] Code compiles and tests pass for the touched modules (`./gradlew :module-name:test`, or `./gradlew build` for cross-module changes)
- [x] New behavior is covered by unit or integration tests

### 📝 Additional Notes

Evidence — the new rule was sanity-checked by reverting the fix, which produces exactly the two expected violations:

```
Method <io.kestra.plugin.core.kv.PurgeKV.run(...)> calls method <io.kestra.core.runners.Services.additionalService(...)> in (PurgeKV.java:102)
Method <io.kestra.plugin.core.namespace.PurgeFiles.run(...)> calls method <io.kestra.core.runners.Services.additionalService(...)> in (PurgeFiles.java:100)
```

With the fix in place: `:tests:test --tests SystemTaskArchitectureTest` passes, and `:core:test --tests PurgeKVTest --tests PurgeFilesTest` is green (21 tests).

Not verified end to end on a real distributed deployment. The existing purge tests call `task.run(runContext)` directly and so never exercised the routing; the dispatch path itself is covered by `WorkerQueueServiceTest`.
