### PR TITLE
fix(executions): correct visible column count in metrics table custom…

### DIFF
--- a/ui/src/components/executions/ExecutionMetric.vue
+++ b/ui/src/components/executions/ExecutionMetric.vue
@@ -13,6 +13,7 @@
                 :properties="{
                     shown: true,
                     columns: optionalColumns,
+                    displayColumns: table?.displayColumns,
                     storageKey: 'execution-metrics'
                 }"
                 :prefix="'execution-metrics'"
@@ -40,7 +41,7 @@
 
     const metricFilter = useMetricFilter()
 
-    const table = ref<typeof MetricsTable>()
+    const table = ref<InstanceType<typeof MetricsTable>>()
 
     const taskRunId = computed(() => route.query["filters[metric][EQUALS]"] as string | undefined)
 

--- a/ui/src/components/executions/MetricsTable.vue
+++ b/ui/src/components/executions/MetricsTable.vue
@@ -200,6 +200,7 @@
     defineExpose({
         loadData,
         updateDisplayColumns,
+        displayColumns,
         reload: () => dataTable.value?.reload(),
     })
 </script>


### PR DESCRIPTION
…ization panel

closes: #19397

### ✨ Description

Exposed `displayColumns` from `MetricsTable.vue` so that `ExecutionMetric.vue` can read the current column visibility state and correctly pass it down to `KSFilter`'s properties.


https://github.com/user-attachments/assets/530d04cc-f372-4b69-ad4c-21f75f737ec7

