### PR TITLE
fix(triggers): recover stuck polling evaluation locks

### DIFF
--- a/scheduler/src/test/java/io/kestra/scheduler/TriggerSchedulerTest.java
+++ b/scheduler/src/test/java/io/kestra/scheduler/TriggerSchedulerTest.java
@@ -251,6 +251,34 @@ class TriggerSchedulerTest {
     }
 
     @Test
+    void shouldNotLockPollingTriggerWhenWorkerJobIsNotDispatched() throws Exception {
+        // region [GIVEN]
+        FlowWithSource flow = Fixtures.flowWithTrigger(
+            TestPollingTrigger.builder()
+                .id("polling")
+                .type(TestPollingTrigger.class.getName())
+                .interval(Duration.ofMinutes(30))
+                .build()
+        );
+        TriggerWorkerJobPublisher publisher = Mockito.mock(TriggerWorkerJobPublisher.class);
+        Mockito.when(publisher.send(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any())).thenReturn(false);
+        TriggerScheduler scheduler = newTriggerScheduler(List.of(flow), publisher);
+        scheduler.onStart(SchedulerClock.getClock(), SchedulerClock.now().toInstant(), NODES_ASSIGNMENTS);
+        // endregion [GIVEN]
+
+        // WHEN
+        scheduler.onSchedule(SchedulerClock.getClock(), SchedulerClock.now().toInstant(), NODES_ASSIGNMENTS);
+
+        // THEN — the evaluation lock is not taken when dispatch is a no-op, so the trigger stays
+        // eligible instead of being silently stuck until a manual unlock.
+        TriggerState state = triggerStateStore.findByIdWithoutAcl(Fixtures.triggerId("polling")).orElse(null);
+        assertThat(state).isNotNull();
+        assertThat(state.isLocked()).isFalse();
+        assertThat(state.getLastTriggeredDate()).isNull();
+        assertThat(state.getNextEvaluationDate()).isEqualTo(SchedulerClock.now().plusMinutes(30).toInstant());
+    }
+
+    @Test
     void shouldSucceedScheduleScheduleOnDateTriggerGivenValidTimeZone() {
         // region [GIVEN]
         SchedulerClock.setClock(Clock.fixed(Instant.parse("2025-10-31T00:00:00Z"), ZoneId.systemDefault()));

--- a/worker/src/main/java/io/kestra/worker/processors/internals/AbstractWorkerCallable.java
+++ b/worker/src/main/java/io/kestra/worker/processors/internals/AbstractWorkerCallable.java
@@ -3,7 +3,11 @@ package io.kestra.worker.processors.internals;
 import java.time.Duration;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.slf4j.Logger;
 
@@ -13,8 +17,6 @@ import io.kestra.core.models.flows.State;
 import io.kestra.core.runners.RunContext;
 import io.kestra.core.utils.Exceptions;
 
-import dev.failsafe.Failsafe;
-import dev.failsafe.Timeout;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.StatusCode;
 import lombok.Getter;
@@ -25,6 +27,12 @@ import static io.kestra.core.models.flows.State.Type.*;
 
 @SuppressWarnings("this-escape")
 public abstract class AbstractWorkerCallable implements Callable<State.Type> {
+    private static final ScheduledExecutorService TIMEOUT_SCHEDULER = Executors.newSingleThreadScheduledExecutor(runnable -> {
+        Thread thread = new Thread(runnable, "worker-job-timeout");
+        thread.setDaemon(true);
+        return thread;
+    });
+
     /** The state to report once interrupted, or {@code null} if not interrupted (or interrupted without marking, e.g. on timeout). */
     volatile State.Type killedState = null;
 
@@ -143,15 +151,12 @@ public abstract class AbstractWorkerCallable implements Callable<State.Type> {
     }
 
     /**
-     * Runs {@code work} bounded by an interruptible {@code timeout} ({@code null} = unbounded).
+     * Runs {@code work} bounded by {@code timeout} ({@code null} = unbounded).
      * <p>
-     * On timeout the worker thread is interrupted to awake blocking calls (e.g. a stuck
-     * {@code KafkaConsumer.poll()}), the interrupt flag is then cleared so it does not leak to later
-     * operations, {@code onTimeout} is invoked (e.g. a metric increment), and the timeout is recorded
-     * via {@link #exceptionHandler} — returning {@code FAILED} (or {@code KILLED}). When {@code work}
-     * completes within the timeout this returns {@code null} and the caller maps its own success state.
-     * Failsafe wraps checked exceptions thrown by {@code work}; the cause is unwrapped and rethrown so
-     * callers handle it exactly as they would without a timeout.
+     * When the timeout fires, {@link #kill(State.Type)} is invoked immediately on a watchdog
+     * thread with a {@code null} state so the job reports {@code FAILED} rather than {@code KILLED}.
+     * Subclass {@code kill()} also runs plugin {@code kill()}; interrupt alone does not unblock
+     * some I/O (e.g. {@code KafkaConsumer.poll()}). Completing within the timeout returns {@code null}.
      *
      * @param onTimeout action to run when the timeout fires; may be {@code null}
      * @return the terminal state on timeout, or {@code null} if {@code work} completed in time
@@ -162,28 +167,36 @@ public abstract class AbstractWorkerCallable implements Callable<State.Type> {
             return null;
         }
 
-        Timeout<Object> failsafeTimeout = Timeout
-            .builder(timeout)
-            .withInterrupt() // use to awake blocking evaluations, e.g. a stuck KafkaConsumer.poll().
-            .build();
-        try {
-            Failsafe.with(failsafeTimeout).run(work::run);
-            return null;
-        } catch (dev.failsafe.TimeoutExceededException e) {
-            if (onTimeout != null) {
-                onTimeout.run();
+        AtomicBoolean timedOut = new AtomicBoolean(false);
+        ScheduledFuture<?> timeoutTask = TIMEOUT_SCHEDULER.schedule(() -> {
+            if (timedOut.compareAndSet(false, true)) {
+                try {
+                    if (onTimeout != null) {
+                        onTimeout.run();
+                    }
+                } finally {
+                    kill((State.Type) null);
+                }
             }
-            kill(null);
-            // Clear the interrupt flag set by Failsafe's withInterrupt() so it doesn't leak to the caller.
-            Thread.interrupted();
-            return this.exceptionHandler(new TimeoutExceededException(timeout));
-        } catch (dev.failsafe.FailsafeException e) {
-            // Failsafe wraps checked exceptions; unwrap so they are handled like a normal failure.
-            if (e.getCause() instanceof Exception cause) {
-                throw cause;
+        }, timeout.toNanos(), TimeUnit.NANOSECONDS);
+
+        try {
+            work.run();
+        } catch (Exception e) {
+            if (timedOut.get()) {
+                Thread.interrupted();
+                return this.exceptionHandler(new TimeoutExceededException(timeout));
             }
             throw e;
+        } finally {
+            timeoutTask.cancel(false);
         }
+
+        if (timedOut.get()) {
+            Thread.interrupted();
+            return this.exceptionHandler(new TimeoutExceededException(timeout));
+        }
+        return null;
     }
 
     public void interrupt() {

--- a/worker/src/test/java/io/kestra/worker/processors/internals/WorkerTaskCallableTest.java
+++ b/worker/src/test/java/io/kestra/worker/processors/internals/WorkerTaskCallableTest.java
@@ -1,0 +1,119 @@
+package io.kestra.worker.processors.internals;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.jupiter.api.Test;
+
+import io.kestra.core.exceptions.TimeoutExceededException;
+import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.metrics.MetricRegistry;
+import io.kestra.core.models.executions.Execution;
+import io.kestra.core.models.executions.TaskRun;
+import io.kestra.core.models.flows.Flow;
+import io.kestra.core.models.flows.State;
+import io.kestra.core.models.property.Property;
+import io.kestra.core.models.tasks.ResolvedTask;
+import io.kestra.core.models.tasks.RunnableTask;
+import io.kestra.core.models.tasks.Task;
+import io.kestra.core.models.tasks.VoidOutput;
+import io.kestra.core.runners.RunContext;
+import io.kestra.core.runners.RunContextFactory;
+import io.kestra.core.runners.WorkerTask;
+import io.kestra.core.runners.WorkerTaskData;
+import io.kestra.core.utils.IdUtils;
+import io.kestra.core.utils.TestsUtils;
+import io.kestra.core.worker.WorkerGroups;
+
+import jakarta.inject.Inject;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTimeout;
+
+@KestraTest
+class WorkerTaskCallableTest {
+    @Inject
+    private RunContextFactory runContextFactory;
+
+    @Inject
+    private MetricRegistry metricRegistry;
+
+    @Test
+    void shouldFailAndInvokeKillWhenTaskExceedsTimeout() {
+        // Given: a task that ignores interrupt and only returns after kill(), with a short timeout
+        HangUntilKilledTask task = HangUntilKilledTask.builder()
+            .id("hang-task")
+            .type(HangUntilKilledTask.class.getName())
+            .timeout(Property.ofValue(Duration.ofMillis(200)))
+            .build();
+        WorkerTaskCallable callable = callable(task);
+
+        // When
+        State.Type state = assertTimeout(Duration.ofSeconds(5), callable::call);
+
+        // Then: timeout is reported as FAILED with TimeoutExceededException, and kill() ran
+        // while the task was still blocked so the worker slot is released.
+        assertThat(state).isEqualTo(State.Type.FAILED);
+        assertThat(callable.getException()).isInstanceOf(TimeoutExceededException.class);
+        assertThat(task.wasKilled()).isTrue();
+    }
+
+    private WorkerTaskCallable callable(HangUntilKilledTask task) {
+        Flow flow = Flow.builder()
+            .id(IdUtils.create())
+            .namespace("io.kestra.unit-test")
+            .tasks(List.of(task))
+            .build();
+
+        Execution execution = TestsUtils.mockExecution(flow, Map.of());
+        ResolvedTask resolvedTask = ResolvedTask.of(task);
+        RunContext runContext = runContextFactory.of(Map.of("key", "value"));
+
+        WorkerTask workerTask = WorkerTask.builder()
+            .data(WorkerTaskData.from(runContext))
+            .task(task)
+            .taskRun(TaskRun.of(execution, resolvedTask))
+            .build();
+
+        return new WorkerTaskCallable(workerTask, task, runContext, metricRegistry, WorkerGroups.DEFAULT_ID);
+    }
+
+    /**
+     * Task whose {@code run()} ignores interrupt and only returns after {@link #kill()}.
+     * Proves the timeout watchdog invokes {@code task.kill()} instead of waiting forever.
+     */
+    @SuperBuilder
+    @Getter
+    @NoArgsConstructor
+    public static class HangUntilKilledTask extends Task implements RunnableTask<VoidOutput> {
+        @Builder.Default
+        private final AtomicBoolean killed = new AtomicBoolean(false);
+
+        @Override
+        public VoidOutput run(RunContext runContext) {
+            while (!killed.get()) {
+                try {
+                    Thread.sleep(50);
+                } catch (InterruptedException ignored) {
+                    // Swallow interrupt — only kill() unblocks this task.
+                }
+            }
+            return null;
+        }
+
+        @Override
+        public void kill() {
+            killed.set(true);
+        }
+
+        public boolean wasKilled() {
+            return killed.get();
+        }
+    }
+}

--- a/worker/src/test/java/io/kestra/worker/processors/internals/WorkerTriggerCallableTest.java
+++ b/worker/src/test/java/io/kestra/worker/processors/internals/WorkerTriggerCallableTest.java
@@ -4,6 +4,7 @@ import java.time.Duration;
 import java.time.ZonedDateTime;
 import java.util.Collections;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.junit.jupiter.api.Test;
 
@@ -14,6 +15,7 @@ import io.kestra.core.models.flows.State;
 import io.kestra.core.models.triggers.AbstractTrigger;
 import io.kestra.core.models.triggers.PollingTriggerInterface;
 import io.kestra.core.models.triggers.TriggerContext;
+import io.kestra.core.models.triggers.TriggerEvaluationResult;
 import io.kestra.core.runners.RunContext;
 import io.kestra.core.runners.RunContextInitializer;
 import io.kestra.core.runners.WorkerTrigger;
@@ -21,8 +23,13 @@ import io.kestra.core.runners.WorkerTriggerData;
 import io.kestra.core.tasks.test.SleepTrigger;
 
 import jakarta.inject.Inject;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTimeout;
 
 @KestraTest
 class WorkerTriggerCallableTest {
@@ -40,7 +47,7 @@ class WorkerTriggerCallableTest {
         WorkerTriggerCallable callable = callable(trigger, Duration.ofMillis(300));
 
         // When
-        State.Type state = callable.call();
+        State.Type state = assertTimeout(Duration.ofSeconds(5), callable::call);
 
         // Then: the evaluation is interrupted, marked failed, and carries a TimeoutExceededException
         // (the caller emits an error trigger result on this, which releases the scheduler lock).
@@ -48,6 +55,24 @@ class WorkerTriggerCallableTest {
         // and skip publishTriggerExecution, so any partial getEvaluate() value is irrelevant here.
         assertThat(state).isEqualTo(State.Type.FAILED);
         assertThat(callable.getException()).isInstanceOf(TimeoutExceededException.class);
+    }
+
+    @Test
+    void shouldKillAndFreeWorkerWhenEvaluationIgnoresInterrupt() {
+        // Given: an evaluation that swallows Thread.interrupt() — only plugin kill() unblocks it
+        HangUntilKilledTrigger trigger = HangUntilKilledTrigger.builder()
+            .id("hang")
+            .type(HangUntilKilledTrigger.class.getName())
+            .build();
+        WorkerTriggerCallable callable = callable(trigger, Duration.ofMillis(200));
+
+        // When: timeout must invoke kill() while eval is still blocked, unblocking the worker
+        State.Type state = assertTimeout(Duration.ofSeconds(5), callable::call);
+
+        // Then
+        assertThat(state).isEqualTo(State.Type.FAILED);
+        assertThat(callable.getException()).isInstanceOf(TimeoutExceededException.class);
+        assertThat(trigger.wasKilled()).isTrue();
     }
 
     @Test
@@ -84,5 +109,42 @@ class WorkerTriggerCallableTest {
         RunContext runContext = conditionContext.getRunContext();
 
         return new WorkerTriggerCallable(runContext, conditionContext, triggerContext, workerTrigger, (PollingTriggerInterface) trigger, timeout);
+    }
+
+    /**
+     * Polling trigger whose {@code eval()} ignores interrupt and only returns after {@link #kill()}.
+     */
+    @SuperBuilder
+    @Getter
+    @NoArgsConstructor
+    public static class HangUntilKilledTrigger extends AbstractTrigger implements PollingTriggerInterface {
+        @Builder.Default
+        private final AtomicBoolean killed = new AtomicBoolean(false);
+
+        @Override
+        public Optional<TriggerEvaluationResult> eval(ConditionContext conditionContext, TriggerContext context) {
+            while (!killed.get()) {
+                try {
+                    Thread.sleep(50);
+                } catch (InterruptedException ignored) {
+                    // Swallow interrupt — only kill() unblocks this evaluation.
+                }
+            }
+            return Optional.empty();
+        }
+
+        @Override
+        public void kill() {
+            killed.set(true);
+        }
+
+        public boolean wasKilled() {
+            return killed.get();
+        }
+
+        @Override
+        public Duration getInterval() {
+            return Duration.ofSeconds(1);
+        }
     }
 }


### PR DESCRIPTION
## Problem

A polling trigger on the JDBC backend can stay locked forever when evaluation produces **no result**. Thrown exceptions already released the lock; the leak came from a missing result.

Two cases:

1. **Hanging evaluation.** `evaluate()` ran with no timeout. A blocking call that ignores `Thread.interrupt()` (for example a stuck `KafkaConsumer.poll()`) wedged the worker thread. No `WorkerTriggerResult` was emitted, so `TriggerState.locked` stayed `true` until a manual unlock.
2. **No dispatch.** If the worker job was never sent, taking the lock first left the trigger locked with nothing running. The 2.x scheduler already locks only after a successful dispatch; this change adds a polling-specific regression test for that path.

PR #17446 added `Timeout.withInterrupt()` but called `kill()` only **after** `evaluate()` returned. Interrupt alone does not unblock `poll()`, so the worker stayed occupied and the lock was never released.

## Fix

- Bound polling-trigger evaluation with `kestra.worker.polling-trigger-timeout` (default `10m`).
- When the timeout fires, a watchdog thread calls `kill(false)` immediately (`trigger.kill()` / `task.kill()` plus interrupt), matching `WorkerJobLifecycle`. That is what actually unblocks plugin I/O (e.g. `consumer.wakeup()`).
- `onTimeout` runs in `try/finally` so `kill(false)` still runs if the metric callback throws.
- Task timeouts share the same `callWithTimeout` path (replacing Failsafe). Timeout still reports `FAILED` + `TimeoutExceededException`, not `KILLED`.
- Realtime triggers are unchanged.

A hang that ignores interrupt **and** whose plugin `kill()` is a no-op still occupies the worker. That is the existing plugin contract.

## Tests

- `WorkerTriggerCallableTest`: interruptible hang, interrupt-ignoring hang, in-time success
- `WorkerTaskCallableTest`: timed-out task is `FAILED` with `TimeoutExceededException` and `task.kill()` is invoked
- `TriggerSchedulerTest.shouldNotLockPollingTriggerWhenWorkerJobIsNotDispatched`

## Config

```yaml
kestra:
  worker:
    polling-trigger-timeout: 10m
```

Lower this if faster hang recovery is desired. The default is generous so legitimate long evaluations are not cut.

FIxses #17445