### PR TITLE
fix(ui): clarify execution dashboard titles(#19009)

### DIFF
--- a/core/src/main/resources/dashboards/default_flow_definition.yaml
+++ b/core/src/main/resources/dashboards/default_flow_definition.yaml
@@ -92,7 +92,7 @@ charts:
   - id: total_executions_pie
     type: io.kestra.plugin.core.dashboard.chart.Pie
     chartOptions:
-      displayName: Total Executions
+      displayName: Executions by status
       graphStyle: DONUT
       tooltip: ALL
       width: 6
@@ -110,7 +110,7 @@ charts:
   - id: total_executions_timeseries
     type: io.kestra.plugin.core.dashboard.chart.TimeSeries
     chartOptions:
-      displayName: Total Executions
+      displayName: Executions over time
       description: Executions duration and count per date
       legend:
         enabled: true

--- a/core/src/main/resources/dashboards/default_main_definition.yaml
+++ b/core/src/main/resources/dashboards/default_main_definition.yaml
@@ -83,7 +83,7 @@ charts:
   - id: total_executions_timeseries
     type: io.kestra.plugin.core.dashboard.chart.TimeSeries
     chartOptions:
-      displayName: Total Executions
+      displayName: Executions over time
       description: Executions duration and count per date
       legend:
         enabled: true
@@ -111,7 +111,7 @@ charts:
   - id: total_executions_pie
     type: io.kestra.plugin.core.dashboard.chart.Pie
     chartOptions:
-      displayName: Total Executions
+      displayName: Executions by status
       description: By status
       graphStyle: DONUT
       tooltip: ALL

--- a/core/src/main/resources/dashboards/default_namespace_definition.yaml
+++ b/core/src/main/resources/dashboards/default_namespace_definition.yaml
@@ -80,7 +80,7 @@ charts:
   - id: total_executions_timeseries
     type: io.kestra.plugin.core.dashboard.chart.TimeSeries
     chartOptions:
-      displayName: Total Executions
+      displayName: Executions over time
       description: Executions duration and count per date
       legend:
         enabled: true
@@ -108,7 +108,7 @@ charts:
   - id: total_executions_pie
     type: io.kestra.plugin.core.dashboard.chart.Pie
     chartOptions:
-      displayName: Total Executions
+      displayName: Executions by status
       graphStyle: DONUT
       tooltip: ALL
       width: 3


### PR DESCRIPTION
### 🔗 Related Issue

Closes #19009.

### ✨ Description

The default dashboards currently use the same `Total Executions` title for two different execution charts, making them difficult to distinguish when the subtitles are unavailable.

This PR gives each panel a descriptive title:

- `Executions over time` for the execution time-series chart.
- `Executions by status` for the execution status donut chart.

The titles are updated consistently across the default main, namespace, and flow dashboards.

### 🛠️ Backend Checklist

- [ ] Code compiles and tests pass for the touched modules (`./gradlew :module-name:test`, or `./gradlew build` for cross-module changes)
- [ ] New behavior is covered by unit or integration tests

### 📝 Additional Notes

The change is limited to the three default dashboard definition YAML files. No changes were made to the generic `TimeSeries` or `Pie` chart implementations.

`git diff --check` passes successfully, and the final diff contains only the six intended `displayName` changes.

### 🤖 AI Authors

N/A.